### PR TITLE
Added development integration test (local only)

### DIFF
--- a/sidecar/app/tests/app_test.go
+++ b/sidecar/app/tests/app_test.go
@@ -25,19 +25,23 @@ var inputMetaFilePath string
 
 //TODO: Use individual directories per test to enable parallelism
 
-var persistentBlobDir string
+var persistentInBlobDir string
+var persistentOutBlobDir string
 var persistentEventsDir string
 
 var a app.App
 var db types.MetadataProvider
 
 func TestMain(m *testing.M) {
+	eventID := "01010101"
+	parentEventID := "10101010"
 	outputBlobDir = path.Join("testdata", "out", "data")
 	inputBlobDir = path.Join("testdata", "in", "data")
 	outputEventsDir = path.Join("testdata", "out", "events")
 	outputMetaFilePath = path.Join("testdata", "out", "meta.json")
 	inputMetaFilePath = path.Join("testdata", "out", "meta.json")
-	persistentBlobDir = path.Join("testdata", "blob")
+	persistentInBlobDir = path.Join("testdata", parentEventID, "blob")
+	persistentOutBlobDir = path.Join("testdata", eventID, "blob")
 	persistentEventsDir = path.Join("testdata", "events")
 
 	var err error
@@ -46,7 +50,8 @@ func TestMain(m *testing.M) {
 		panic(fmt.Sprintf("failed to create in memory DB with error '%+v'", err))
 	}
 	blob, err := filesystem.NewBlobStorage(&filesystem.Config{
-		BaseDir: persistentBlobDir,
+		InputDir:  persistentInBlobDir,
+		OutputDir: persistentOutBlobDir,
 	})
 	if err != nil {
 		panic(fmt.Sprintf("failed to create file system storage with error '%+v'", err))
@@ -120,7 +125,7 @@ func TestCommitBlob(t *testing.T) {
 			t.Errorf("error commiting test blobs '%+v'", err)
 			continue
 		}
-		files, err := ioutil.ReadDir(persistentBlobDir)
+		files, err := ioutil.ReadDir(persistentOutBlobDir)
 		if err != nil {
 			t.Errorf("error reading blob directory '%+v'", err)
 			continue
@@ -137,11 +142,11 @@ func TestCommitBlob(t *testing.T) {
 		}
 
 		// Refresh blob directory between tests
-		_ = os.RemoveAll(persistentBlobDir)
-		_ = os.Mkdir(persistentBlobDir, 0777)
+		_ = os.RemoveAll(persistentOutBlobDir)
+		_ = os.Mkdir(persistentOutBlobDir, 0777)
 	}
 	// Clear blob directory
-	_ = os.RemoveAll(persistentBlobDir)
+	_ = os.RemoveAll(persistentOutBlobDir)
 }
 
 func TestCommitMeta(t *testing.T) {

--- a/sidecar/main.go
+++ b/sidecar/main.go
@@ -3,14 +3,19 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+
 	"os"
+	"path"
 	"runtime"
 	"strings"
 
 	"github.com/containous/flaeg"
 	"github.com/lawrencegripper/ion/sidecar/app"
 	"github.com/lawrencegripper/ion/sidecar/blob/azurestorage"
+	"github.com/lawrencegripper/ion/sidecar/blob/filesystem"
+	"github.com/lawrencegripper/ion/sidecar/events/mock"
 	"github.com/lawrencegripper/ion/sidecar/events/servicebus"
+	"github.com/lawrencegripper/ion/sidecar/meta/inmemory"
 	"github.com/lawrencegripper/ion/sidecar/meta/mongodb"
 	"github.com/lawrencegripper/ion/sidecar/types"
 	log "github.com/sirupsen/logrus"
@@ -19,8 +24,10 @@ import (
 // cSpell:ignore flaeg, logrus, mongodb
 
 const (
-	defaultPort           = 8080
-	defaultWindowsBaseDir = "" // blank will result in /ion/... being used
+	defaultPort = 8080
+
+	// blank base dir will result in /ion/ being used
+	defaultWindowsBaseDir = ""
 	defaultLinuxBaseDir   = ""
 	defaultDarwinBaseDir  = ""
 )
@@ -40,8 +47,8 @@ func main() {
 			if config.PrintConfig {
 				fmt.Println(prettyPrintStruct(*config))
 			}
-			if config.SharedSecret == "" || config.Context.EventID == "" || config.Context.CorrelationID == "" {
-				return fmt.Errorf("Missing configuration. Use '--printconfig' to show current config on start")
+			if err := validateConfig(config); err != nil {
+				return err
 			}
 			runApp(config)
 			return nil
@@ -130,28 +137,47 @@ func addDefaults(c *app.Configuration) {
 	}
 }
 
+func validateConfig(c *app.Configuration) error {
+	if c.SharedSecret == "" || c.Context.EventID == "" || c.Context.CorrelationID == "" {
+		return fmt.Errorf("Missing configuration. Use '--printconfig' to show current config on start")
+	}
+	//TODO: When more providers are added,
+	// we need to check the configuration to
+	// ensure only 1 for each type is set.
+	// Alternatively, we allow multiple
+	// provider configs and just return the
+	// first we check against.
+}
+
 func getMetaProvider(config *app.Configuration) types.MetadataProvider {
-	metaProviders := make([]types.MetadataProvider, 0)
+	if config.Development {
+		inMemDB, err := inmemory.NewInMemoryDB()
+		if err != nil {
+			panic(fmt.Errorf("Failed to establish metadata store with debug provider, error: %+v", err))
+		}
+		return inMemDB
+	}
 	if config.MongoDBMetaProvider != nil {
 		c := config.MongoDBMetaProvider
 		mongoDB, err := mongodb.NewMongoDB(c)
 		if err != nil {
 			panic(fmt.Errorf("Failed to establish metadata store with provider '%s', error: %+v", types.MetaProviderMongoDB, err))
 		}
-		metaProviders = append(metaProviders, mongoDB)
+		return mongoDB
 	}
-	// Do this rather than return a subset (first) of the providers to encourage quick failure
-	if len(metaProviders) > 1 {
-		panic("Only 1 metadata provider can be supplied")
-	}
-	if len(metaProviders) == 0 {
-		panic("No metadata provider supplied, please add one.")
-	}
-	return metaProviders[0]
+	return nil
 }
 
 func getBlobProvider(config *app.Configuration) types.BlobProvider {
-	blobProviders := make([]types.BlobProvider, 0)
+	if config.Development {
+		fsBlob, err := filesystem.NewBlobStorage(&filesystem.Config{
+			BaseDir: path.Join(types.DevBaseDir, "blobs"),
+		})
+		if err != nil {
+			panic(fmt.Errorf("Failed to establish metadata store with debug provider, error: %+v", err))
+		}
+		return fsBlob
+	}
 	if config.AzureBlobProvider != nil {
 		c := config.AzureBlobProvider
 		azureBlob, err := azurestorage.NewBlobStorage(c,
@@ -160,34 +186,23 @@ func getBlobProvider(config *app.Configuration) types.BlobProvider {
 		if err != nil {
 			panic(fmt.Errorf("Failed to establish blob storage with provider '%s', error: %+v", types.BlobProviderAzureStorage, err))
 		}
-		blobProviders = append(blobProviders, azureBlob)
+		return azureBlob
 	}
-	// Do this rather than return a subset (first) of the providers to encourage quick failure
-	if len(blobProviders) > 1 {
-		panic("Only 1 metadata provider can be supplied")
-	}
-	if len(blobProviders) == 0 {
-		panic("No metadata provider supplied, please add one.")
-	}
-	return blobProviders[0]
+	return nil
 }
 
 func getEventProvider(config *app.Configuration) types.EventPublisher {
-	eventProviders := make([]types.EventPublisher, 0)
+	if config.Development {
+		fsEvents := mock.NewEventPublisher(path.Join(types.DevBaseDir, "events"))
+		return fsEvents
+	}
 	if config.ServiceBusEventProvider != nil {
 		c := config.ServiceBusEventProvider
 		serviceBus, err := servicebus.NewServiceBus(c)
 		if err != nil {
 			panic(fmt.Errorf("Failed to establish event publisher with provider '%s', error: %+v", types.EventProviderServiceBus, err))
 		}
-		eventProviders = append(eventProviders, serviceBus)
+		return serviceBus
 	}
-	// Do this rather than return a subset (first) of the providers to encourage quick failure
-	if len(eventProviders) > 1 {
-		panic("Only 1 metadata provider can be supplied")
-	}
-	if len(eventProviders) == 0 {
-		panic("No metadata provider supplied, please add one.")
-	}
-	return eventProviders[0]
+	return nil
 }

--- a/sidecar/main.go
+++ b/sidecar/main.go
@@ -147,6 +147,7 @@ func validateConfig(c *app.Configuration) error {
 	// Alternatively, we allow multiple
 	// provider configs and just return the
 	// first we check against.
+	return nil
 }
 
 func getMetaProvider(config *app.Configuration) types.MetadataProvider {
@@ -171,7 +172,8 @@ func getMetaProvider(config *app.Configuration) types.MetadataProvider {
 func getBlobProvider(config *app.Configuration) types.BlobProvider {
 	if config.Development {
 		fsBlob, err := filesystem.NewBlobStorage(&filesystem.Config{
-			BaseDir: path.Join(types.DevBaseDir, "blobs"),
+			InputDir:  path.Join(types.DevBaseDir, config.Context.ParentEventID, "blobs"),
+			OutputDir: path.Join(types.DevBaseDir, config.Context.EventID, "blobs"),
 		})
 		if err != nil {
 			panic(fmt.Errorf("Failed to establish metadata store with debug provider, error: %+v", err))

--- a/sidecar/types/constants.go
+++ b/sidecar/types/constants.go
@@ -29,4 +29,7 @@ const (
 
 	//FilesToInclude is the key in the metadata to extract the event type using
 	FilesToInclude string = "files"
+
+	//DevBaseDir is the base directory for development mode output
+	DevBaseDir string = ".dev"
 )

--- a/sidecar/types/helpers.go
+++ b/sidecar/types/helpers.go
@@ -63,6 +63,9 @@ func ClearDir(dirPath string) error {
 
 //RemoveFile removes a file from the file system
 func RemoveFile(filePath string) error {
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		return nil // If file doesn't exist - return as if succeeded
+	}
 	err := os.Remove(filePath)
 	if err != nil {
 		return fmt.Errorf("failed to remove file at path '%s' with error: '%+v'", filePath, err)

--- a/sidecar/types/tests/helpers_test.go
+++ b/sidecar/types/tests/helpers_test.go
@@ -120,7 +120,7 @@ func TestRemoveFile(t *testing.T) {
 		},
 		{
 			filename: "",
-			removed:  false,
+			removed:  true,
 		},
 	}
 	for _, test := range testCases {


### PR DESCRIPTION
When `--development` is set to true, the sidecar will use local only providers and dump additional files for debugging.

Should this automatically set log level to verbose?

Includes integration test that is runnable locally without any configuration.