### PR TITLE
Added init for worker env vars map

### DIFF
--- a/internal/app/dispatcher/providers/azurebatch.go
+++ b/internal/app/dispatcher/providers/azurebatch.go
@@ -56,6 +56,7 @@ func NewAzureBatchProvider(config *types.Configuration, sharedHandlerArgs []stri
 	b.batchConfig = config.AzureBatch
 	b.jobConfig = config.Job
 	b.jobID = config.Hostname + "-" + config.ModuleName
+	b.workerEnvVars = make(map[string]interface{})
 	ctx, cancel := context.WithCancel(context.Background())
 	b.ctx = ctx
 	b.cancelOps = cancel


### PR DESCRIPTION
Currently the worker env var map is not initialized before it is written to in `azurebatch.go`.