### PR TITLE
Redactor logger

### DIFF
--- a/internal/pkg/logger/redactor.go
+++ b/internal/pkg/logger/redactor.go
@@ -1,0 +1,65 @@
+package logger
+
+import (
+	"bytes"
+
+	"github.com/sirupsen/logrus"
+)
+
+type RedactorFunc func([]byte) []byte
+
+type Redactor struct {
+	backend logrus.Formatter
+
+	Redactor RedactorFunc
+}
+
+func (redactor Redactor) Format(entry *logrus.Entry) ([]byte, error) {
+	serialized, err := redactor.backend.Format(entry)
+
+	if err == nil {
+		serialized = redactor.Redactor(serialized)
+	}
+
+	return serialized, err
+}
+
+func (redactor *Redactor) init() {
+	redactor.Redactor = func(in []byte) []byte { return in }
+}
+
+func NewJsonRedactor() Redactor {
+	redactor := Redactor{}
+	redactor.backend = new(logrus.JSONFormatter)
+	return redactor
+}
+
+func NewJsonSecretRedactor(fun RedactorFunc) Redactor {
+	redactor := Redactor{}
+	redactor.backend = new(logrus.JSONFormatter)
+	redactor.Redactor = fun
+	return redactor
+}
+
+func NewTextRedactor() Redactor {
+	redactor := Redactor{}
+	redactor.backend = new(logrus.TextFormatter)
+	return redactor
+}
+
+func NewTextSecretRedactor(fun RedactorFunc) Redactor {
+	redactor := Redactor{}
+	redactor.backend = new(logrus.TextFormatter)
+	redactor.Redactor = fun
+	return redactor
+}
+
+func NewSecretRedact(secrets [][]byte, redacted []byte) RedactorFunc {
+	return func(serialized []byte) []byte {
+		out := serialized
+		for _, s := range secrets {
+			out = bytes.Replace(out, s, redacted, -1)
+		}
+		return out
+	}
+}


### PR DESCRIPTION
Add a simple mechanism to hide credential using a redactor formatter for logrus.

To use it, you can create either a NewTextRedactor() to get the default TextFormatter from logrus and have the possibility to create your own redactor function or a NewTextSecretRedactor to define a redactor using you own redactor function.

To help you to create your redactor, you can use NewSecretRedact(secrets [][]byte, redacted []byte) that replace all secrets by redacted.

To use this formatter you have to set it into your logrus logger.