### PR TITLE
Support sub directories and allow bigger blob uploads

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -8,6 +8,12 @@
   revision = "e9dc86bbf0e5bbe6bf7ff5a6f71e048959b61f71"
 
 [[projects]]
+  name = "github.com/Azure/azure-pipeline-go"
+  packages = ["pipeline"]
+  revision = "7571e8eb0876932ab505918ff7ed5107773e5ee2"
+  version = "0.1.7"
+
+[[projects]]
   name = "github.com/Azure/azure-sdk-for-go"
   packages = [
     "services/batch/2017-09-01.6.0/batch",
@@ -48,6 +54,12 @@
   name = "github.com/PuerkitoBio/urlesc"
   packages = ["."]
   revision = "de5bf2ad457846296e2031421a34e2568e304e35"
+
+[[projects]]
+  name = "github.com/azure/azure-storage-blob-go"
+  packages = ["2016-05-31/azblob"]
+  revision = "66ba96e49ebbdc3cd26970c6c675c906d304b5e2"
+  version = "0.1.4"
 
 [[projects]]
   name = "github.com/dgrijalva/jwt-go"
@@ -638,6 +650,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "c89b34d7bdfe7e3def73631d305fc2f126369afe577157f11b45d44fc4c5290f"
+  inputs-digest = "5b7290c1f5f1c53135bd8118971ec0da653cd08ffab9c1c7d1d020e2cc9adcee"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -66,3 +66,7 @@
 [[constraint]]
   branch = "master"
   name = "github.com/jjcollinge/logrus-appinsights"
+
+[[constraint]]
+  name = "github.com/azure/azure-storage-blob-go"
+  version = "0.1.4"

--- a/internal/app/handler/committer/tests/committer_test.go
+++ b/internal/app/handler/committer/tests/committer_test.go
@@ -119,7 +119,7 @@ func TestCommitBlob(t *testing.T) {
 	for _, test := range testCases {
 		for _, file := range test.files {
 			dirPath := filepath.Dir(file)
-			dirPathInEnv := path.Join(environment.OutputBlobDirPath, dir)
+			dirPathInEnv := path.Join(environment.OutputBlobDirPath, dirPath)
 			_ = os.MkdirAll(dirPathInEnv, os.ModePerm)
 			outputFilePath := filepath.Join(environment.OutputBlobDirPath, file)
 			f, err := os.Create(outputFilePath)

--- a/internal/app/handler/committer/tests/committer_test.go
+++ b/internal/app/handler/committer/tests/committer_test.go
@@ -41,6 +41,9 @@ func TestMain(m *testing.M) {
 	persistentEventsDir = filepath.FromSlash(fmt.Sprintf("%s/events", testdata))
 	eventTypes = append(eventTypes, "test_events")
 
+	environment = module.GetModuleEnvironment(testdata)
+	environment.Build()
+
 	// Create mock dataplane...
 
 	// Metadata store
@@ -53,7 +56,7 @@ func TestMain(m *testing.M) {
 	blob, err := filesystem.NewBlobStorage(&filesystem.Config{
 		InputDir:  persistentInBlobDir,
 		OutputDir: persistentOutBlobDir,
-	})
+	}, environment)
 	if err != nil {
 		panic(fmt.Sprintf("failed to create file system storage with error '%+v'", err))
 	}
@@ -74,9 +77,6 @@ func TestMain(m *testing.M) {
 		CorrelationID: "frank",
 		ParentEventID: "parentid",
 	}
-
-	environment = module.GetModuleEnvironment(testdata)
-	environment.Build()
 
 	// Create committer
 	log.SetOutput(os.Stdout)

--- a/internal/app/handler/committer/tests/committer_test.go
+++ b/internal/app/handler/committer/tests/committer_test.go
@@ -119,13 +119,8 @@ func TestCommitBlob(t *testing.T) {
 	for _, test := range testCases {
 		for _, file := range test.files {
 			dirPath := filepath.Dir(file)
-			dirs := filepath.SplitList(dirPath)
-			for _, dir := range dirs {
-				dirPathInEnv := path.Join(environment.OutputBlobDirPath, dir)
-				if _, err := os.Stat(dirPathInEnv); os.IsNotExist(err) {
-					_ = os.Mkdir(dirPathInEnv, os.ModePerm)
-				}
-			}
+			dirPathInEnv := path.Join(environment.OutputBlobDirPath, dir)
+			_ = os.MkdirAll(dirPathInEnv, os.ModePerm)
 			outputFilePath := filepath.Join(environment.OutputBlobDirPath, file)
 			f, err := os.Create(outputFilePath)
 			f.Close()

--- a/internal/app/handler/dataplane/blobstorage/filesystem/filesystem.go
+++ b/internal/app/handler/dataplane/blobstorage/filesystem/filesystem.go
@@ -6,6 +6,9 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
+
+	"github.com/lawrencegripper/ion/internal/app/handler/module"
 )
 
 //Config to setup a FileSystem storage provider
@@ -18,10 +21,11 @@ type Config struct {
 type BlobStorage struct {
 	inDir  string
 	outDir string
+	env    *module.Environment
 }
 
 //NewBlobStorage creates a new file system blob provider
-func NewBlobStorage(config *Config) (*BlobStorage, error) {
+func NewBlobStorage(config *Config, env *module.Environment) (*BlobStorage, error) {
 	err := os.MkdirAll(config.OutputDir, os.ModePerm)
 	if err != nil {
 		return nil, fmt.Errorf("error creating directory for filesystem blob provider '%+v'", err)
@@ -29,6 +33,7 @@ func NewBlobStorage(config *Config) (*BlobStorage, error) {
 	fs := &BlobStorage{
 		inDir:  config.InputDir,
 		outDir: config.OutputDir,
+		env:    env,
 	}
 	return fs, nil
 }
@@ -37,8 +42,14 @@ func NewBlobStorage(config *Config) (*BlobStorage, error) {
 func (a *BlobStorage) PutBlobs(filePaths []string) (map[string]string, error) {
 	uris := make(map[string]string)
 	for _, filePath := range filePaths {
-		_, nakedFilePath := filepath.Split(filePath)
+		nakedFilePath := strings.Replace(filePath, a.env.OutputBlobDirPath, "", -1)
+		if nakedFilePath[0] == '/' {
+			nakedFilePath = nakedFilePath[1:]
+		}
 		destPath := filepath.FromSlash(path.Join(a.outDir, nakedFilePath))
+		if err := os.MkdirAll(filepath.Dir(destPath), os.ModePerm); err != nil {
+			return nil, fmt.Errorf("error creating output directory %s: %+v", destPath, err)
+		}
 		if err := copy(filePath, destPath); err != nil {
 			return nil, fmt.Errorf("error copying file to blob storage '%+v'", err)
 		}
@@ -56,6 +67,8 @@ func (a *BlobStorage) GetBlobs(outputDir string, filePaths []string) error {
 			return fmt.Errorf("error getting blob '%s': '%+v'", file, err)
 		}
 		destPath := filepath.FromSlash(path.Join(outputDir, file))
+		destDir := filepath.Dir(destPath)
+		_ = os.MkdirAll(destDir, os.ModePerm)
 		if err := copy(srcPath, destPath); err != nil {
 			return fmt.Errorf("error copying from blob '%s': '%+v'", file, err)
 		}

--- a/internal/app/handler/dataplane/blobstorage/filesystem/filesystem.go
+++ b/internal/app/handler/dataplane/blobstorage/filesystem/filesystem.go
@@ -22,7 +22,7 @@ type BlobStorage struct {
 
 //NewBlobStorage creates a new file system blob provider
 func NewBlobStorage(config *Config) (*BlobStorage, error) {
-	err := os.MkdirAll(config.OutputDir, 0777)
+	err := os.MkdirAll(config.OutputDir, os.ModePerm)
 	if err != nil {
 		return nil, fmt.Errorf("error creating directory for filesystem blob provider '%+v'", err)
 	}

--- a/internal/app/handler/dataplane/documentstorage/documentstorage.go
+++ b/internal/app/handler/dataplane/documentstorage/documentstorage.go
@@ -4,6 +4,11 @@ import (
 	"github.com/lawrencegripper/ion/internal/pkg/common"
 )
 
+const (
+	// NotFoundErr returned when a document is not found in document storage
+	NotFoundErr = "document not found"
+)
+
 //Insight is used to export structure data
 type Insight struct {
 	*common.Context

--- a/internal/app/handler/dataplane/documentstorage/inmemory/inmemory.go
+++ b/internal/app/handler/dataplane/documentstorage/inmemory/inmemory.go
@@ -70,7 +70,7 @@ func (db *InMemoryDB) Close() {
 	if err != nil {
 		panic("Failed to serialize self on close")
 	}
-	err = ioutil.WriteFile(onDiskName, b, 0777)
+	err = ioutil.WriteFile(onDiskName, b, os.ModePerm)
 	if err != nil {
 		panic("Failed to write serialized self to file")
 	}

--- a/internal/app/handler/dataplane/documentstorage/inmemory/inmemory.go
+++ b/internal/app/handler/dataplane/documentstorage/inmemory/inmemory.go
@@ -9,7 +9,9 @@ import (
 	"github.com/lawrencegripper/ion/internal/app/handler/dataplane/documentstorage"
 )
 
-const onDiskName = ".memdb"
+const (
+	onDiskName = ".memdb"
+)
 
 //nolint:golint
 //InMemoryDB is an in memory DB
@@ -47,7 +49,7 @@ func NewInMemoryDB() (*InMemoryDB, error) {
 func (db *InMemoryDB) GetEventMetaByID(id string) (*documentstorage.EventMeta, error) {
 	context, exist := db.Contexts[id]
 	if !exist {
-		return nil, fmt.Errorf("no record found for id '%s'", id)
+		return nil, fmt.Errorf("%s %s", documentstorage.NotFoundErr, id)
 	}
 	return &context, nil
 }

--- a/internal/app/handler/dataplane/documentstorage/mongodb/mongodb.go
+++ b/internal/app/handler/dataplane/documentstorage/mongodb/mongodb.go
@@ -17,6 +17,11 @@ import (
 
 // cSpell:ignore mongodb, bson, upsert
 
+const (
+	// mongoDBNotFoundErr returned when a document does not exist
+	mongoDBNotFoundErr = "not found"
+)
+
 //Config used to setup a MongoDB metastore provider
 type Config struct {
 	Enabled    bool   `description:"Enable MongoDB metadata provider"`
@@ -67,7 +72,10 @@ func (db *MongoDB) GetEventMetaByID(id string) (*documentstorage.EventMeta, erro
 	eventMeta := documentstorage.EventMeta{}
 	err := db.Collection.Find(bson.M{"id": id}).One(&eventMeta)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get document with ID %s, error: %+v", id, err)
+		if err.Error() == mongoDBNotFoundErr {
+			return nil, fmt.Errorf("%s %s", documentstorage.NotFoundErr, id)
+		}
+		return nil, fmt.Errorf("error get document %s, error: %+v", id, err)
 	}
 	return &eventMeta, nil
 }

--- a/internal/app/handler/dataplane/events/mock/mock.go
+++ b/internal/app/handler/dataplane/events/mock/mock.go
@@ -19,7 +19,7 @@ type EventPublisher struct {
 
 //NewEventPublisher returns a new EventPublisher object
 func NewEventPublisher(dir string) *EventPublisher {
-	err := os.MkdirAll(dir, 0777)
+	err := os.MkdirAll(dir, os.ModePerm)
 	if err != nil {
 		return nil
 	}
@@ -36,7 +36,7 @@ func (e *EventPublisher) Publish(event common.Event) error {
 	if err != nil {
 		return fmt.Errorf("error marshalling event '%+v'", err)
 	}
-	err = ioutil.WriteFile(eventPath, eventJSON, 0777)
+	err = ioutil.WriteFile(eventPath, eventJSON, os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("error writing event to file '%s': '%+v'", eventPath, err)
 	}

--- a/internal/app/handler/development/config.go
+++ b/internal/app/handler/development/config.go
@@ -35,7 +35,7 @@ func (c *Configuration) Init(parentEventID, eventID string) error {
 	}
 
 	if _, err := os.Stat(c.BaseDir); os.IsNotExist(err) {
-		if err = os.MkdirAll(c.BaseDir, 0777); err != nil {
+		if err = os.MkdirAll(c.BaseDir, os.ModePerm); err != nil {
 			return fmt.Errorf("error creating development base directory %+v", err)
 		}
 	}
@@ -62,24 +62,24 @@ func (c *Configuration) Init(parentEventID, eventID string) error {
 	// If parentModuleDir is empty, assume module is root of tree
 	moduleDir := filepath.Join(prefix, c.ParentModuleDir, eventID)
 	if _, err := os.Stat(moduleDir); os.IsNotExist(err) {
-		_ = os.Mkdir(moduleDir, 0777)
+		_ = os.Mkdir(moduleDir, os.ModePerm)
 	}
 	blobsDir := filepath.Join(moduleDir, BlobsDirExt)
 	if _, err := os.Stat(blobsDir); os.IsNotExist(err) {
-		_ = os.Mkdir(blobsDir, 0777)
+		_ = os.Mkdir(blobsDir, os.ModePerm)
 	}
 	eventsDir := filepath.Join(moduleDir, EventsDirExt)
 	if _, err := os.Stat(eventsDir); os.IsNotExist(err) {
-		_ = os.Mkdir(eventsDir, 0777)
+		_ = os.Mkdir(eventsDir, os.ModePerm)
 
 	}
 	metadataDir := filepath.Join(moduleDir, MetadataDirExt)
 	if _, err := os.Stat(metadataDir); os.IsNotExist(err) {
-		_ = os.Mkdir(metadataDir, 0777)
+		_ = os.Mkdir(metadataDir, os.ModePerm)
 	}
 	insightsDir := filepath.Join(moduleDir, InsightsDirExt)
 	if _, err := os.Stat(insightsDir); os.IsNotExist(err) {
-		_ = os.Mkdir(insightsDir, 0777)
+		_ = os.Mkdir(insightsDir, os.ModePerm)
 	}
 
 	if moduleDir == "" {
@@ -142,7 +142,7 @@ func (c *Configuration) writeOutput(filename string, dir string, obj interface{}
 	if err != nil {
 		return fmt.Errorf("error generating development logs, '%+v'", err)
 	}
-	err = ioutil.WriteFile(path, b, 0777)
+	err = ioutil.WriteFile(path, b, os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("error writing development logs, '%+v'", err)
 	}

--- a/internal/app/handler/helpers/helpers.go
+++ b/internal/app/handler/helpers/helpers.go
@@ -38,7 +38,7 @@ func ClearDir(dirPath string) error {
 	if err != nil {
 		return fmt.Errorf("failed removing directory path '%s' with error: '%+v'", dirPath, err)
 	}
-	err = os.MkdirAll(dirPath, 0777)
+	err = os.MkdirAll(dirPath, os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("failed creating directory path '%s' with error: '%+v'", dirPath, err)
 	}
@@ -85,7 +85,7 @@ func ContainsString(slice []string, target string) bool {
 //CreateDirClean creates a directory - deleting any existing directory
 func CreateDirClean(dirPath string) error {
 	_ = os.RemoveAll(dirPath)
-	if err := os.MkdirAll(dirPath, 0777); err != nil {
+	if err := os.MkdirAll(dirPath, os.ModePerm); err != nil {
 		return fmt.Errorf("error creating directory '%s': '%+v'", dirPath, err)
 	}
 	return nil

--- a/internal/app/handler/helpers/tests/helpers_test.go
+++ b/internal/app/handler/helpers/tests/helpers_test.go
@@ -154,7 +154,7 @@ func TestClearDir(t *testing.T) {
 		},
 	}
 	for _, test := range testCases {
-		_ = os.MkdirAll(test.dirname, 0777)
+		_ = os.MkdirAll(test.dirname, os.ModePerm)
 		for _, file := range test.files {
 			path := path.Join(test.dirname, file)
 			f, err := os.Create(path)

--- a/internal/app/handler/integration/azure_intergration_test.go
+++ b/internal/app/handler/integration/azure_intergration_test.go
@@ -105,7 +105,8 @@ func TestAzureIntegration(t *testing.T) {
 	// Write an output image blob
 	blob2 := "subdir/img2.png"
 	blob2FilePath := path.Join(environment.OutputBlobDirPath, blob2)
-	writeOutputBlob(blob2FilePath)
+	//writeOutputBlob(blob2FilePath)
+	writeLargeOutputBlob(blob2FilePath, 10)
 
 	// Grab the length of the output directory
 	var outFiles []string

--- a/internal/app/handler/integration/dev_integration_test.go
+++ b/internal/app/handler/integration/dev_integration_test.go
@@ -155,7 +155,7 @@ func TestDevIntegration(t *testing.T) {
 }
 
 func writeOutputBlob(path string) error {
-	err := ioutil.WriteFile(path, []byte("image1"), 0777)
+	err := ioutil.WriteFile(path, []byte("image1"), os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("error writing file '%s', '%+v'", path, err)
 	}
@@ -163,7 +163,7 @@ func writeOutputBlob(path string) error {
 }
 
 func writeOutputBytes(bytes []byte, path string) error {
-	err := ioutil.WriteFile(path, bytes, 0777)
+	err := ioutil.WriteFile(path, bytes, os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("error writing file '%s', '%+v'", bytes, err)
 	}

--- a/internal/app/handler/integration/dev_integration_test.go
+++ b/internal/app/handler/integration/dev_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/lawrencegripper/ion/internal/app/handler/development"
 	"github.com/lawrencegripper/ion/internal/app/handler/module"
 	"io/ioutil"
+	"math"
 	"os"
 	"path"
 	"path/filepath"
@@ -166,6 +167,27 @@ func TestDevIntegration(t *testing.T) {
 		}
 		break
 	}
+}
+
+func writeLargeOutputBlob(path string, sizeInMB float64) error {
+	dir := filepath.Dir(path)
+	if dir != "." {
+		_ = os.MkdirAll(dir, os.ModePerm)
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	kb := sizeInMB * 1024
+	b := kb * 1024
+	for i := 0; i < int(math.Ceil(b)); i++ {
+		if _, err := f.Write([]byte{255}); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func writeOutputBlob(path string) error {

--- a/internal/app/handler/preparer/preparer.go
+++ b/internal/app/handler/preparer/preparer.go
@@ -6,6 +6,7 @@ import (
 	"github.com/lawrencegripper/ion/internal/app/handler/development"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"github.com/lawrencegripper/ion/internal/app/handler/dataplane"
 	"github.com/lawrencegripper/ion/internal/app/handler/dataplane/documentstorage"
@@ -155,7 +156,12 @@ func (p *Preparer) prepareData() error {
 }
 
 func (p *Preparer) getEventMeta() (*documentstorage.EventMeta, error) {
-	context, _ := p.dataPlane.GetEventMetaByID(p.context.EventID)
-	//TODO: Fail on error conditions other than not found
-	return context, nil
+	context, err := p.dataPlane.GetEventMetaByID(p.context.EventID)
+	if err != nil {
+		if strings.HasPrefix(err.Error(), documentstorage.NotFoundErr) {
+			logger.Info(p.context, "no event meta found, likely invoked manually")
+			return context, nil // Ignore not found errors
+		}
+	}
+	return context, err // Return all other errors
 }

--- a/internal/app/handler/preparer/preparer.go
+++ b/internal/app/handler/preparer/preparer.go
@@ -114,7 +114,7 @@ func (p *Preparer) prepareEnv() error {
 	// If in development enabled, make sure the development directories exist
 	if p.devConfig.Enabled {
 		if _, err := os.Stat(p.devConfig.ModuleDir); os.IsNotExist(err) {
-			_ = os.MkdirAll(p.devConfig.ModuleDir, 0777)
+			_ = os.MkdirAll(p.devConfig.ModuleDir, os.ModePerm)
 		}
 	}
 	return nil
@@ -145,7 +145,7 @@ func (p *Preparer) prepareData() error {
 			if err != nil {
 				return err
 			}
-			err = ioutil.WriteFile(p.environment.InputMetaFilePath, b, 0777)
+			err = ioutil.WriteFile(p.environment.InputMetaFilePath, b, os.ModePerm)
 			if err != nil {
 				return err
 			}

--- a/internal/pkg/management/trace/trace.pb.go
+++ b/internal/pkg/management/trace/trace.pb.go
@@ -34,7 +34,7 @@ func (m *GetFlowRequest) Reset()         { *m = GetFlowRequest{} }
 func (m *GetFlowRequest) String() string { return proto.CompactTextString(m) }
 func (*GetFlowRequest) ProtoMessage()    {}
 func (*GetFlowRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_trace_24f21ce4024d85b8, []int{0}
+	return fileDescriptor_trace_9e18cb942ae3326e, []int{0}
 }
 func (m *GetFlowRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GetFlowRequest.Unmarshal(m, b)
@@ -72,7 +72,7 @@ func (m *GetFlowResponse) Reset()         { *m = GetFlowResponse{} }
 func (m *GetFlowResponse) String() string { return proto.CompactTextString(m) }
 func (*GetFlowResponse) ProtoMessage()    {}
 func (*GetFlowResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_trace_24f21ce4024d85b8, []int{1}
+	return fileDescriptor_trace_9e18cb942ae3326e, []int{1}
 }
 func (m *GetFlowResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GetFlowResponse.Unmarshal(m, b)
@@ -176,9 +176,9 @@ var _TraceService_serviceDesc = grpc.ServiceDesc{
 	Metadata: "trace.proto",
 }
 
-func init() { proto.RegisterFile("trace.proto", fileDescriptor_trace_24f21ce4024d85b8) }
+func init() { proto.RegisterFile("trace.proto", fileDescriptor_trace_9e18cb942ae3326e) }
 
-var fileDescriptor_trace_24f21ce4024d85b8 = []byte{
+var fileDescriptor_trace_9e18cb942ae3326e = []byte{
 	// 153 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0xe2, 0x2e, 0x29, 0x4a, 0x4c,
 	0x4e, 0xd5, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x57, 0x32, 0xe3, 0xe2, 0x73, 0x4f, 0x2d, 0x71, 0xcb,


### PR DESCRIPTION
This change supports subdirectories for blob data and drops to the lower Azure blob API to support larger than 256MB file uploads.

Addresses:
#150 #133 